### PR TITLE
Add inline-check drop support to pick-a-lock macro

### DIFF
--- a/module/macros/pick-a-lock.js
+++ b/module/macros/pick-a-lock.js
@@ -92,6 +92,64 @@ async function renderPickLockDialog(actor) {
             SKILL_MOD = mod;
           });
         }
+
+        const reqInput =
+          form.querySelector("[data-req-input]") ??
+          form.querySelector("[name=requestCheck]") ??
+          form.querySelector("[name=request]") ??
+          form.querySelector("[name=req]");
+        const reqPayload =
+          form.querySelector("[data-req-payload]") ??
+          form.querySelector("[name=requestPayload]") ??
+          form.querySelector("[name=reqPayload]");
+        const reqDrop =
+          form.querySelector("[data-req-drop]") ??
+          form.querySelector("[data-inline-check-drop]") ??
+          reqInput ??
+          null;
+
+        const updateReqPayload = (rawText) => {
+          if (!reqPayload) return;
+
+          const text = typeof rawText === "string" ? rawText.trim() : "";
+          const match = text.match(/@Check\[[^\]]+\]/i);
+          reqPayload.value = match ? match[0] : "";
+        };
+
+        if (reqInput) {
+          reqInput.addEventListener("input", () => {
+            updateReqPayload(reqInput.value);
+          });
+          reqInput.addEventListener("change", () => {
+            updateReqPayload(reqInput.value);
+          });
+          updateReqPayload(reqInput.value);
+        }
+
+        if (reqDrop) {
+          const assignFromText = (text) => {
+            if (!text) return;
+            if (reqInput) {
+              reqInput.value = text;
+            }
+            updateReqPayload(text);
+          };
+
+          reqDrop.addEventListener("dragenter", (event) => {
+            event.preventDefault();
+          });
+
+          reqDrop.addEventListener("dragover", (event) => {
+            event.preventDefault();
+          });
+
+          reqDrop.addEventListener("drop", (event) => {
+            event.preventDefault();
+            const droppedText = event.dataTransfer?.getData("text/plain");
+            if (!droppedText) return;
+            assignFromText(droppedText.trim());
+          });
+        }
       },
       buttons: {
         start: {


### PR DESCRIPTION
## Summary
- update the Pick a Lock macro dialog setup to look for inline-check inputs and payload fields
- synchronize the hidden payload whenever the requirement field changes or receives dropped text
- allow dragged inline-check strings to be dropped by cancelling dragenter/dragover defaults

## Testing
- not run (not feasible in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e2ad44a43c83278ab8d2e22c5dbcef