### PR TITLE
Add Foundry module manifest

### DIFF
--- a/module/module.json
+++ b/module/module.json
@@ -1,0 +1,42 @@
+{
+  "id": "kazguls-pf2e-macros",
+  "title": "Kazgul's PF2e Macros",
+  "description": "A collection of automation macros for the Pathfinder Second Edition system.",
+  "version": "1.0.0",
+  "compatibility": {
+    "minimum": "11",
+    "verified": "11.309"
+  },
+  "authors": [
+    {
+      "name": "Kazgul1987",
+      "url": "https://github.com/Kazgul1987"
+    }
+  ],
+  "url": "https://github.com/Kazgul1987/Kazguls-PF2e-Macros",
+  "manifest": "https://raw.githubusercontent.com/Kazgul1987/Kazguls-PF2e-Macros/main/module/module.json",
+  "download": "https://github.com/Kazgul1987/Kazguls-PF2e-Macros/releases/download/v1.0.0/kazguls-pf2e-macros.zip",
+  "license": "LICENSE",
+  "readme": "https://github.com/Kazgul1987/Kazguls-PF2e-Macros/blob/main/README.md",
+  "changelog": "https://github.com/Kazgul1987/Kazguls-PF2e-Macros/releases",
+  "bugs": "https://github.com/Kazgul1987/Kazguls-PF2e-Macros/issues",
+  "flags": {},
+  "esmodules": [],
+  "scripts": [
+    "macros/pick-a-lock.js"
+  ],
+  "styles": [],
+  "packs": [],
+  "languages": [],
+  "relationships": {
+    "systems": [
+      {
+        "id": "pf2e",
+        "type": "system",
+        "compatibility": {
+          "minimum": "5.7.0"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a Foundry VTT module manifest with metadata and compatibility details
- register the existing pick-a-lock macro script so Foundry can load it

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2b15f4f58832795ad74258db86772