### PR TITLE
Fix Pick a Lock macro execution and skill detection

### DIFF
--- a/module/macros/pick-a-lock.js
+++ b/module/macros/pick-a-lock.js
@@ -230,7 +230,11 @@ function getSkillMod(actor, key) {
     perception: ["perception", "per"],
   };
 
-  const searchKeys = [...(alias[key] ?? []), key]
+  const aliasMatches = Object.values(alias)
+    .filter((values) => values.includes(key))
+    .flat();
+
+  const searchKeys = [...(alias[key] ?? []), ...aliasMatches, key]
     .filter((value, index, array) => typeof value === "string" && array.indexOf(value) === index);
 
   for (const slug of searchKeys) {
@@ -1034,3 +1038,5 @@ if (game?.modules?.get) {
     });
   }
 }
+
+pickALock();


### PR DESCRIPTION
## Summary
- ensure the Pick a Lock macro executes by calling pickALock()
- expand skill alias resolution so abbreviated skill keys resolve to their modifiers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e382c751308327981a4017b8cd748d