### PR TITLE
Fix skill modifier retrieval for non-custom skills

### DIFF
--- a/module/macros/pick-a-lock.js
+++ b/module/macros/pick-a-lock.js
@@ -256,7 +256,9 @@ if (!form) return;
 
 /******************** Parse Grunddaten ********************/
 const skillKey = form.skill;
-const SKILL_MOD = num(form.skillmod, 0);
+const SKILL_MOD = (skillKey === "custom")
+  ? num(form.skillmod, 0)
+  : getSkillMod(actor, skillKey);
 const preset  = LOCK_PRESETS[form.locktype] ?? LOCK_PRESETS["Simple (level 1)"];
 let DC      = (form.locktype !== "Eigene Werte") ? preset.dc     : num(form.dc, preset.dc);
 let NEEDED  = (form.locktype !== "Eigene Werte") ? preset.needed : Math.max(1, num(form.needed, preset.needed));


### PR DESCRIPTION
## Summary
- derive the skill modifier from the actor when a predefined skill is selected instead of reading the disabled input

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e38c9d63988327aedade01acfec385